### PR TITLE
Edge-case bug where FileUtils.copy won't get called for non-audio files 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ tmp
 *(copie)*
 # RVM
 .rvmrc
+# rbenv
+.ruby-version
+# pry
+.pryrc
 # VisualRuby
 .vr_settings.yaml
 # Emacs
@@ -43,9 +47,9 @@ tmp
 *.geany
 # RubyMine
 .idea
-#RedCar
+# RedCar
 .redcar
-#ruby-debug
+# ruby-debug
 .rdebugrc
-#Eclipse
+# Eclipse
 .metadata/

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ tmp
 .idea
 #RedCar
 .redcar
+#ruby-debug
+.rdebugrc
+#Eclipse
+.metadata/

--- a/lib/batch_audio_convert/file_utils.rb
+++ b/lib/batch_audio_convert/file_utils.rb
@@ -38,9 +38,9 @@ module FileUtils
     false
   end
 
-  # Define destination name and transormation method to apply for a file.
+  # Define destination name and transformation method to apply for a file.
   def analyze_file(file)
-    method_name = :copy
+    method_name = :default_copy
     destination_file = String.new(file)
     config[:extensions].each do |origin_ext, destination_ext|
       origin_ext = origin_ext.to_s
@@ -55,7 +55,7 @@ module FileUtils
     return {:method_name => method_name, :destination_file => destination_file}
   end
 
-  def copy(origin, destination)
+  def default_copy(origin, destination)
     puts_and_logs "Copying \"#{origin}\" to \"#{destination}\"."
     return if config[:simulate]
     unless should_process_file? destination


### PR DESCRIPTION
I've renamed FileUtils.copy to default_copy to fix a small bug: If there is a non-audio file in a source directory and it is enumerated first in the list of files to be copied (e.g., "AlbumArt.jpg"), the destination dir doesn't get created and we get an exception thrown.

This is because the local FileUtils.copy doesn't get called, and hence it doesn't call verify_destination_folder, which should create the directory. Instead, FileUtils.cp in the Ruby stdlib gets called, because it's aliased there as "copy". I have no idea why the alias prevails over the local method; I would expect the local to override the alias. It might have something to do with the stdlib using module_function to make cp & copy available??? There might be a more meta way of fixing this problem, e.g., "undef copy" to remove the alias, but I'm not sure how that would work. 

(And sorry about my including the .gitignore changes--I'm still a GitHub newbie and couldn't figure out how to exclude those commits from the pull request.) 
